### PR TITLE
Update Package Info & GitHub CI

### DIFF
--- a/.github/workflows/publish-pypi.yaml
+++ b/.github/workflows/publish-pypi.yaml
@@ -1,0 +1,30 @@
+name: Upload to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build
+    - name: Build package
+      run: python -m build
+    - name: Publish package
+      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}
+        repository_url: https://pypi.org/legacy/
+

--- a/.github/workflows/pytest-skipped.yaml
+++ b/.github/workflows/pytest-skipped.yaml
@@ -11,7 +11,7 @@ on:
       - '.github/workflows/pytest.yaml'
   pull_request:
     branches: [ main ]
-    paths:
+    paths-ignore:
       - 'src/**'
       - 'tests/**'
       - '.github/workflows/pytest.yaml'

--- a/.github/workflows/pytest-skipped.yaml
+++ b/.github/workflows/pytest-skipped.yaml
@@ -1,0 +1,23 @@
+# This workflow should allow protected branches to merge when Pytest is a required check
+# While modifying pytest.yaml will invalidate tests, modifying this file (pytest-skipped.yaml) will not invalidate tests
+name: Pytest
+
+on:
+  push:
+    branches: [ main ]
+    paths-ignore:
+      - 'src/**'
+      - 'tests/**'
+      - '.github/workflows/pytest.yaml'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - '.github/workflows/pytest.yaml'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No build required" '

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -6,8 +6,16 @@ name: Pytest
 on:
   push:
     branches: [ main ]
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - '.github/workflows/pytest.yaml'
   pull_request:
     branches: [ main ]
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - '.github/workflows/pytest.yaml'
 
 jobs:
   build:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,17 +1,20 @@
 [metadata]
-name = struct-lib
-version = 2022.1-b0
+name = obj-struct-lib
+version = 2022.1-b1
 author = Marcus Kertesz
-description = An object-oriented alternative to the built-in struct module. Still uses struct under the hood, but allows defining user structures, and packing into/from binaryio/bytesio types.
+description = An object-oriented alternative to the built-in struct module.
 long_description = file: README.md
 long_description_content_type = text/markdown
 url = https://github.com/ModernMAK/Object-Struct-Library
 project_urls =
     Bug Tracker = https://github.com/ModernMAK/Object-Struct-Library/issues
 classifiers =
-    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     License :: OSI Approved :: MIT License
     Operating System :: OS Independent
+    Topic :: Software Development :: Libraries
 
 [options]
 package_dir =


### PR DESCRIPTION
Adds auto-release pypi workflow
Specifies proper version classifiers (previously specified only Python 3.0); now properly specifies 3.9, 3.10 support, which readme badges should reflect. 

I'm uncertain if I did properly setup CI to ignore minor modifications, will find out later I suppose